### PR TITLE
feat: Add cookies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "bootstrap": "^5.3.3",
+        "js-cookie": "^3.0.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "reactstrap": "^9.2.2"
@@ -3150,6 +3151,14 @@
         "has-symbols": "^1.0.3",
         "reflect.getprototypeof": "^1.0.4",
         "set-function-name": "^2.0.1"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@popperjs/core": "^2.11.8",
     "bootstrap": "^5.3.3",
+    "js-cookie": "^3.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "reactstrap": "^9.2.2"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,21 +1,35 @@
 import "bootstrap/dist/css/bootstrap.min.css";
 import { set } from "immutable";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button, Form, FormGroup, Input, Label, ListGroup } from "reactstrap";
 import DeleteBtn from "./DeleteBtn";
 import TodoListItem from "./TodoListItem";
+import Cookies from "js-cookie";
 
 const App = () => {
   const [inputVal, setInputVal] = useState("");
   const [todos, setTodos] = useState([]);
   const [checkedTodos, setCheckedTodos] = useState([]);
   const [errors, setErrors] = useState([]);
+  const [taskIdCounter, setTaskIdCounter] = useState(1);
+
+  useEffect(() => {
+    if (Cookies.get() && Object.keys(Cookies.get()).length > 0) {
+      parseCookies();
+    }
+  }, []);
 
   function addNewTodo(todo) {
-    setTodos([
-      ...todos,
-      { text: todo, id: Math.random().toString(16).slice(2) },
-    ]);
+    setTodos([...todos, { text: todo, id: taskIdCounter }]);
+  }
+
+  function parseCookies() {
+    const cookies = Cookies.get();
+    const cookieTodos = [];
+    for (const [key, value] of Object.entries(cookies)) {
+      cookieTodos.push({ text: value, id: parseInt(key) });
+    }
+    setTodos([ ...cookieTodos]);
   }
 
   return (
@@ -30,6 +44,8 @@ const App = () => {
           addNewTodo(inputVal);
           setInputVal("");
           setErrors([]);
+          Cookies.set(`${taskIdCounter}`, inputVal);
+          setTaskIdCounter((prev) => prev + 1); // increment taskIdCounter
         }}
         className="container p-5"
       >
@@ -85,7 +101,7 @@ const App = () => {
           />
         </div>
       )}
-      {/* If there are no todo list is empty */}
+      {/* If todos list is empty */}
       {todos.length === 0 ? (
         <div className="container p-5">
           <p className="text-center">No tasks to complete</p>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ const App = () => {
   const [inputVal, setInputVal] = useState("");
   const [todos, setTodos] = useState([]);
   const [checkedTodos, setCheckedTodos] = useState([]);
+  const [errors, setErrors] = useState([]);
 
   function addNewTodo(todo) {
     setTodos([
@@ -16,17 +17,33 @@ const App = () => {
       { text: todo, id: Math.random().toString(16).slice(2) },
     ]);
   }
+
   return (
     <>
       <Form
         onSubmit={(e) => {
           e.preventDefault();
+          if (inputVal.trim() === "") {
+            setErrors(["Todo cannot be empty !"]);
+            return;
+          }
           addNewTodo(inputVal);
           setInputVal("");
+          setErrors([]);
         }}
         className="container p-5"
       >
         <h1 className="text-center mb-5">Todo List App</h1>
+
+        {/* Error display */}
+        {errors.length > 0 ? (
+          <div className="alert alert-danger justify-content-end">
+            {errors.map((error, index) => (
+              <p key={index}>{error}</p>
+            ))}
+          </div>
+        ) : null}
+
         <FormGroup floating>
           <Input
             onChange={(e) => {
@@ -64,6 +81,7 @@ const App = () => {
             setTodos={setTodos}
             checkedTodos={checkedTodos}
             setCheckedTodos={setCheckedTodos}
+            setErrors={setErrors}
           />
         </div>
       )}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -85,6 +85,12 @@ const App = () => {
           />
         </div>
       )}
+      {/* If there are no todo list is empty */}
+      {todos.length === 0 ? (
+        <div className="container p-5">
+          <p className="text-center">No tasks to complete</p>
+        </div>
+      ) : null}
     </>
   );
 };

--- a/src/DeleteBtn.jsx
+++ b/src/DeleteBtn.jsx
@@ -1,4 +1,5 @@
 import { Button } from "reactstrap";
+import Cookies from "js-cookie";
 
 const DeleteBtn = (props) => {
   const { todos, setTodos, checkedTodos, setCheckedTodos, setErrors } = props;
@@ -8,6 +9,7 @@ const DeleteBtn = (props) => {
         setTodos(todos.filter((todo) => !checkedTodos.includes(todo)));
         setCheckedTodos([]);
         setErrors([]);
+        Cookies.remove(`${checkedTodos[0].id}`);
       }}
       className="w-100 p-3"
       color="danger"

--- a/src/DeleteBtn.jsx
+++ b/src/DeleteBtn.jsx
@@ -1,12 +1,13 @@
 import { Button } from "reactstrap";
 
 const DeleteBtn = (props) => {
-  const { todos, setTodos, checkedTodos, setCheckedTodos } = props;
+  const { todos, setTodos, checkedTodos, setCheckedTodos, setErrors } = props;
   return (
     <Button
       onClick={() => {
         setTodos(todos.filter((todo) => !checkedTodos.includes(todo)));
         setCheckedTodos([]);
+        setErrors([]);
       }}
       className="w-100 p-3"
       color="danger"


### PR DESCRIPTION
## Feature description
Installed the [js-cookie API](https://www.npmjs.com/package/js-cookie) . Added ```Cookies.set()``` to store tasks. Now, when the user refreshes or closes the page, the stored tasks/cookies will be rendered to the page.

### Details
- ```useEffect``` was added to check if any ```Cookies``` exist on the initial render. If so, the application will execute ```parseCookies()``` which will render the stored tasks to the page.  
- added ```Cookies.remove()``` to the ```DeleteBtn``` component to ensure the correct cookie is removed along with the task. 
- changed ```todos.id``` to a ```taskIdCounter``` state for consistency since it will be used in ```Cookies``` as well. The counter is incremented whenever the user submits a new task. 
**Note:** I forgot what happens under the hood, but we use essentially use ```setTaskIdCounter((prev) => prev + 1)``` on ```line 48``` to prevent race conditions since state updates asynchronously.

![ezgif com-video-to-gif-converter](https://github.com/dustinusey/todolist-app-bootstrap-react/assets/115957278/4de6f2a2-d702-4fc5-8496-7ebd2504d134)

## Browsers tested
- [x] Mozilla Firefox 123.0.1 (64-bit)
- [x] Google Chrome 122.0.6261.112 (Official Build) (arm64)
- [x] Safari 17.2.1 (latest is 17.3.1)